### PR TITLE
Update 解决Windows获取盘符空值的情况异常 Minion_views.py

### DIFF
--- a/minions/views.py
+++ b/minions/views.py
@@ -36,6 +36,8 @@ def minions_hardware_info(request):
         info_all = sapi.remote_noarg_execution(hostname, 'grains.items')
         disk_use = sapi.remote_noarg_execution(hostname, 'disk.usage')
         for key in disk_use:
+            if disk_use[key]['capacity'] is None:
+                continue
             disk_info = {key: int(disk_use[key]['capacity'][:-1])}
             disk_all.update(disk_info)
             disk_dic = {'disk': disk_all}


### PR DESCRIPTION
解决Windows获取盘符空值获取异常情况
## 

sapi.remote_noarg_execution(u'wincn01', 'disk.usage')  
{u'A:\': {u'available': None, u'1K-blocks': None, u'used': None, u'capacity': None, u'filesystem': u'A:\'}, u'D:\': {u'available': None, u'1K-blocks': None, u'used': None, u'capacity'**:**_*\* None***_***, u'filesystem': u'D:\'}, u'C:\': {u'available': 8405564, u'1K-blocks': 20867068, u'used': 12461504, u'capacity': u'60%', u'filesystem': u'C:\'}}
